### PR TITLE
Added Parse method to be able to parse from an io.ReadSeeker. cleanup…

### DIFF
--- a/cue.go
+++ b/cue.go
@@ -94,7 +94,7 @@ func CueValidate(query, cueFile, currentPath string) (tc CanBeAPart, err error) 
 		ptc, _ := t.Validate(rootValue, CuePath{}, blockedRootFields)
 		tc = ptc
 		if ptc.Error != nil {
-			err = fmt.Errorf(*ptc.Error)
+			err = fmt.Errorf("%s", *ptc.Error)
 			return
 		}
 		ptc.String = query
@@ -108,7 +108,7 @@ func CueValidate(query, cueFile, currentPath string) (tc CanBeAPart, err error) 
 		logicalOperation := t.Validate(rootValue, CuePath{}, blockedRootFields)
 		tc = logicalOperation
 		if logicalOperation.Error != nil {
-			err = fmt.Errorf(*logicalOperation.Error)
+			err = fmt.Errorf("%s", *logicalOperation.Error)
 			return
 		}
 
@@ -288,13 +288,8 @@ func getAvailableFieldsForValue(v cue.Value, blockedRootFields []string) (fields
 			fldName = strings.TrimSuffix(fldName, `"`)
 		}
 
-		if strings.HasSuffix(fldName, "?") {
-			fldName = strings.TrimSuffix(fldName, "?")
-		}
-
-		if strings.HasSuffix(fldName, "!") {
-			fldName = strings.TrimSuffix(fldName, "!")
-		}
+		fldName = strings.TrimSuffix(fldName, "?")
+		fldName = strings.TrimSuffix(fldName, "!")
 
 		fields = append(fields, fldName)
 	}

--- a/funcs.go
+++ b/funcs.go
@@ -1254,7 +1254,7 @@ var (
 					return ""
 				}
 
-				return fmt.Sprintf("is not")
+				return "is not"
 			},
 		},
 		FT_IsNull: {
@@ -1269,7 +1269,7 @@ var (
 					return ""
 				}
 
-				return fmt.Sprintf("is equal to null")
+				return "is equal to null"
 			},
 		},
 		FT_IsNotNull: {
@@ -1284,7 +1284,7 @@ var (
 					return ""
 				}
 
-				return fmt.Sprintf("is not equal to null")
+				return "is not equal to null"
 			},
 		},
 		FT_IsNullOrEmpty: {
@@ -1299,7 +1299,7 @@ var (
 					return ""
 				}
 
-				return fmt.Sprintf("is equal to null or is empty")
+				return "is equal to null or is empty"
 			},
 		},
 		FT_IsNotNullOrEmpty: {
@@ -1314,7 +1314,7 @@ var (
 					return ""
 				}
 
-				return fmt.Sprintf("is not equal to null or is not empty")
+				return "is not equal to null or is not empty"
 			},
 		},
 		FT_IsEmpty: {
@@ -1329,7 +1329,7 @@ var (
 					return ""
 				}
 
-				return fmt.Sprintf("is empty")
+				return "is empty"
 			},
 		},
 		FT_IsNotEmpty: {
@@ -1344,7 +1344,7 @@ var (
 					return ""
 				}
 
-				return fmt.Sprintf("is not empty")
+				return "is not empty"
 			},
 		},
 

--- a/mpath.go
+++ b/mpath.go
@@ -43,7 +43,7 @@ var (
 	}
 )
 
-// Parse takes an io.ReadSeeker and parses it into an operation tree.
+// ParseReadSeeker takes an io.ReadSeeker and parses it into an operation tree.
 func ParseReadSeeker(r io.ReadSeeker) (topOp Operation, err error) {
 	s := scannerPool.Get().(*scanner)
 	defer func() {

--- a/mpath.go
+++ b/mpath.go
@@ -1,7 +1,9 @@
 package mpath
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 	sc "text/scanner"
@@ -10,6 +12,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
 )
+
+var invalidRunes = map[rune]bool{
+	'\'': true, '"': true, '(': true, ')': true, '[': true, ']': true,
+	'{': true, '}': true, '@': true, '$': true, '&': true, '.': true,
+	',': true, '=': true, '>': true, '<': true, '|': true, '!': true,
+	';': true, '/': true, '*': true,
+}
 
 func Setup(jsonMarshalDecimalsWithoutQuotes bool) {
 	decimal.MarshalJSONWithoutQuotes = jsonMarshalDecimalsWithoutQuotes
@@ -21,34 +30,11 @@ var (
 			s := newScanner()
 			s.sx.Mode = sc.ScanIdents | sc.ScanChars | sc.ScanStrings | sc.ScanRawStrings | sc.ScanComments | sc.SkipComments
 			s.sx.IsIdentRune = func(ch rune, i int) bool {
-				// if i == 0 && unicode.IsDigit(ch) {
-				// 	return false
-				// }
+				if invalidRunes[ch] || unicode.IsSpace(ch) {
+					return false
+				}
 
-				return ch != '\'' &&
-					ch != '"' &&
-					ch != '(' &&
-					ch != ')' &&
-					ch != '[' &&
-					ch != ']' &&
-					ch != '{' &&
-					ch != '}' &&
-					ch != '@' &&
-					ch != '$' &&
-					ch != '&' &&
-					ch != '.' &&
-					ch != ',' &&
-					ch != '=' &&
-					ch != '>' &&
-					ch != '<' &&
-					ch != '|' &&
-					ch != '!' &&
-					ch != ';' &&
-					ch != '/' &&
-					ch != '*' &&
-					// ch != '?' && // taken out to allow for null propagation
-					!unicode.IsSpace(ch) &&
-					unicode.IsPrint(ch)
+				return unicode.IsPrint(ch)
 			}
 			s.sx.Error = func(es *sc.Scanner, msg string) {
 				//todo: find a way to pipe this out
@@ -56,35 +42,35 @@ var (
 			return s
 		},
 	}
-	stringsReaderPool = sync.Pool{
-		New: func() any {
-			return &strings.Reader{}
-		},
-	}
 )
 
-func ParseString(ss string) (topOp Operation, err error) {
+// Parse takes an io.ReadSeeker and parses it into an operation tree.
+func Parse(r io.ReadSeeker) (topOp Operation, err error) {
 	s := scannerPool.Get().(*scanner)
-	defer scannerPool.Put(s)
-	sr := stringsReaderPool.Get().(*strings.Reader)
-	defer stringsReaderPool.Put(sr)
-	s.Reset(sr, ss)
+	defer func() {
+		s.err = nil
+		scannerPool.Put(s)
+	}()
 
-	var r rune
-	r = s.Scan()
+	err = s.Reset(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var tok rune
+	tok = s.Scan()
 	for {
-		if r == sc.EOF || r == 0 {
+		if tok == sc.EOF || tok == 0 {
 			break
 		}
 
-		switch r {
+		switch tok {
 		case '{':
 			if topOp != nil {
 				return nil, erAt(s, "operation not terminated properly: found Logical Operation after top operation already defined")
 			}
-			// Curly braces are for logical operation groups (&& and ||)
 			topOp = &opLogicalOperation{}
-			r, err = topOp.Parse(s, r)
+			tok, err = topOp.Parse(s, tok)
 			if err != nil {
 				return nil, err
 			}
@@ -92,9 +78,8 @@ func ParseString(ss string) (topOp Operation, err error) {
 			if topOp != nil {
 				return nil, erAt(s, "operation not terminated properly: found Path after top operation already defined")
 			}
-			// @ and $ are Path starters and specify whether to use the original data, or the data at this point of the path
 			topOp = &opPath{}
-			r, err = topOp.Parse(s, r)
+			tok, err = topOp.Parse(s, tok)
 			if err != nil {
 				return nil, err
 			}
@@ -102,11 +87,21 @@ func ParseString(ss string) (topOp Operation, err error) {
 			if topOp == nil {
 				return nil, errors.Wrap(erInvalid(s, '{', '@', '$'), "invalid query")
 			}
-			return nil, erAt(s, "operation not terminated properly: found '%s' (%d) after top operation already defined", s.TokenText(), r)
+			return nil, erAt(s, "operation not terminated properly: found '%s' (%d) after top operation already defined", s.TokenText(), tok)
 		}
 	}
 
+	// return scanner error if any
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+
 	return
+}
+
+func ParseString(ss string) (topOp Operation, err error) {
+	sr := bytes.NewReader([]byte(ss))
+	return Parse(sr)
 }
 
 func erAt(s *scanner, str string, args ...any) (err error) {
@@ -131,23 +126,30 @@ func erInvalid(s *scanner, validRunes ...rune) error {
 }
 
 type scanner struct {
-	sx *sc.Scanner
+	sx  *sc.Scanner
+	err error
 }
 
 func newScanner() *scanner {
-	return &scanner{
-		sx: &sc.Scanner{},
+	s := &scanner{sx: &sc.Scanner{}}
+	s.sx.Error = func(es *sc.Scanner, msg string) {
+		s.err = errors.New(msg)
 	}
+	return s
 }
 
 func (s *scanner) TokenText() (t string) {
 	return s.sx.TokenText()
 }
 
-func (s *scanner) Reset(sr *strings.Reader, ss string) {
-	sr.Reset(ss)
-	s.sx.Init(sr)
+func (s *scanner) Reset(reader io.ReadSeeker) error {
+	_, err := reader.Seek(0, io.SeekStart)
+	if err != nil {
+		return err
+	}
+	s.sx.Init(reader)
 	s.sx.Mode = sc.ScanIdents | sc.ScanChars | sc.ScanStrings | sc.ScanRawStrings | sc.ScanComments | sc.SkipComments
+	return nil
 }
 
 func (s *scanner) Scan() (r rune) {
@@ -165,4 +167,8 @@ func (s *scanner) Scan() (r rune) {
 		}
 	}
 	return
+}
+
+func (s *scanner) Err() error {
+	return s.err
 }

--- a/mpath.go
+++ b/mpath.go
@@ -1,7 +1,6 @@
 package mpath
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"strings"
@@ -45,7 +44,7 @@ var (
 )
 
 // Parse takes an io.ReadSeeker and parses it into an operation tree.
-func Parse(r io.ReadSeeker) (topOp Operation, err error) {
+func ParseReadSeeker(r io.ReadSeeker) (topOp Operation, err error) {
 	s := scannerPool.Get().(*scanner)
 	defer func() {
 		s.err = nil
@@ -100,8 +99,8 @@ func Parse(r io.ReadSeeker) (topOp Operation, err error) {
 }
 
 func ParseString(ss string) (topOp Operation, err error) {
-	sr := bytes.NewReader([]byte(ss))
-	return Parse(sr)
+	sr := strings.NewReader(ss)
+	return ParseReadSeeker(sr)
 }
 
 func erAt(s *scanner, str string, args ...any) (err error) {

--- a/opPath.go
+++ b/opPath.go
@@ -187,7 +187,7 @@ func (x *opPath) Validate(rootValue cue.Value, cuePath CuePath, blockedRootField
 			// opFilter Validate does not advance the next value
 			pi.Filter = t.Validate(rootValue, cuePath, blockedRootFields)
 			if pi.Filter.Error != nil {
-				return errFunc(fmt.Errorf(*pi.Filter.Error))
+				return errFunc(fmt.Errorf("%s", *pi.Filter.Error))
 			}
 
 		case *opFunction:

--- a/operation.go
+++ b/operation.go
@@ -118,9 +118,7 @@ func AddressedPaths(op Operation) (addressedPaths [][]string) {
 
 			case *opFunction:
 				for _, p := range vv.Params.Paths() {
-					for _, val := range AddressedPaths(p.Value) {
-						addressedPaths = append(addressedPaths, val)
-					}
+					addressedPaths = append(addressedPaths, AddressedPaths(p.Value)...)
 				}
 			}
 		}
@@ -129,9 +127,7 @@ func AddressedPaths(op Operation) (addressedPaths [][]string) {
 
 	case *opLogicalOperation:
 		for _, p := range v.Operations {
-			for _, val := range AddressedPaths(p) {
-				addressedPaths = append(addressedPaths, val)
-			}
+			addressedPaths = append(addressedPaths, AddressedPaths(p)...)
 		}
 	}
 


### PR DESCRIPTION
To enable streaming in tokens, we should be able to pass an io.ReadSeeker and allow mPath to parse from it.
This will give us the following benefits:

* Streaming Input
   - With io.ReadSeeker, you can parse large inputs without loading the entire content into memory at once, making it more efficient for large files or network streams.


* Flexibility
   - The function can accept various input sources such as files (os.File), network responses (http.Response.Body), or even dynamically generated data streams.


* Memory Efficiency
   - Instead of storing a complete string, parsing can be done incrementally, reducing memory footprint.