### PR TITLE
Allow global variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,5 +292,5 @@ Only for use with numbers:
 ### Future planned work:
 
 - Provide the ability to pass in custom functions when initialising the package, and being able to call them by name.
-- Provide the ability to define 'global variables' that can be set prior to the main operation, and then can be referred to by name. The plan here is to use the `#` character to define them, and to use them later. This will mean that variables can be used more efficiently. 
+- Provide the ability to define 'global variables' that can be set prior to the main operation, and then can be referred to by name. The plan here is to use the `#` character to define them, and to use them later. This will mean that variables can be used more efficiently. (DONE)
 - Double check that we're not inefficiently converting decimals.

--- a/cue.go
+++ b/cue.go
@@ -94,7 +94,7 @@ func CueValidate(query, cueFile, currentPath string) (tc CanBeAPart, err error) 
 		ptc, _ := t.Validate(rootValue, CuePath{}, blockedRootFields)
 		tc = ptc
 		if ptc.Error != nil {
-			err = fmt.Errorf(*ptc.Error)
+			err = fmt.Errorf("%s", *ptc.Error)
 			return
 		}
 		ptc.String = query
@@ -108,7 +108,7 @@ func CueValidate(query, cueFile, currentPath string) (tc CanBeAPart, err error) 
 		logicalOperation := t.Validate(rootValue, CuePath{}, blockedRootFields)
 		tc = logicalOperation
 		if logicalOperation.Error != nil {
-			err = fmt.Errorf(*logicalOperation.Error)
+			err = fmt.Errorf("%s", *logicalOperation.Error)
 			return
 		}
 
@@ -288,14 +288,7 @@ func getAvailableFieldsForValue(v cue.Value, blockedRootFields []string) (fields
 			fldName = strings.TrimSuffix(fldName, `"`)
 		}
 
-		if strings.HasSuffix(fldName, "?") {
-			fldName = strings.TrimSuffix(fldName, "?")
-		}
-
-		if strings.HasSuffix(fldName, "!") {
-			fldName = strings.TrimSuffix(fldName, "!")
-		}
-
+		fldName = strings.TrimSuffix(strings.TrimSuffix(fldName, "?"), "!")
 		fields = append(fields, fldName)
 	}
 

--- a/funcs.go
+++ b/funcs.go
@@ -351,7 +351,8 @@ func func_First(rtParams FunctionParameterTypes, val any) (any, error) {
 			return nil, fmt.Errorf("nothing in array")
 		}
 	}
-
+	fmt.Println("!!!!!!!!!!")
+	fmt.Println(val)
 	return false, fmt.Errorf("not array")
 }
 
@@ -1254,7 +1255,7 @@ var (
 					return ""
 				}
 
-				return fmt.Sprintf("is not")
+				return "is not"
 			},
 		},
 		FT_IsNull: {
@@ -1269,7 +1270,7 @@ var (
 					return ""
 				}
 
-				return fmt.Sprintf("is equal to null")
+				return "is equal to null"
 			},
 		},
 		FT_IsNotNull: {
@@ -1284,7 +1285,7 @@ var (
 					return ""
 				}
 
-				return fmt.Sprintf("is not equal to null")
+				return "is not equal to null"
 			},
 		},
 		FT_IsNullOrEmpty: {
@@ -1299,7 +1300,7 @@ var (
 					return ""
 				}
 
-				return fmt.Sprintf("is equal to null or is empty")
+				return "is equal to null or is empty"
 			},
 		},
 		FT_IsNotNullOrEmpty: {
@@ -1314,7 +1315,7 @@ var (
 					return ""
 				}
 
-				return fmt.Sprintf("is not equal to null or is not empty")
+				return "is not equal to null or is not empty"
 			},
 		},
 		FT_IsEmpty: {
@@ -1329,7 +1330,7 @@ var (
 					return ""
 				}
 
-				return fmt.Sprintf("is empty")
+				return "is empty"
 			},
 		},
 		FT_IsNotEmpty: {
@@ -1344,7 +1345,7 @@ var (
 					return ""
 				}
 
-				return fmt.Sprintf("is not empty")
+				return "is not empty"
 			},
 		},
 

--- a/mpath.go
+++ b/mpath.go
@@ -46,6 +46,7 @@ var (
 					ch != ';' &&
 					ch != '/' &&
 					ch != '*' &&
+					ch != '#' &&
 					// ch != '?' && // taken out to allow for null propagation
 					!unicode.IsSpace(ch) &&
 					unicode.IsPrint(ch)
@@ -63,7 +64,10 @@ var (
 	}
 )
 
+// ParseFromReader()
+
 func ParseString(ss string) (topOp Operation, err error) {
+
 	s := scannerPool.Get().(*scanner)
 	defer scannerPool.Put(s)
 	sr := stringsReaderPool.Get().(*strings.Reader)

--- a/opFilter.go
+++ b/opFilter.go
@@ -53,7 +53,7 @@ func (x *opFilter) Do(currentData, originalData any) (dataToUse any, err error) 
 			return nil, err
 		}
 
-		if _, ok := res.(bool); ok {
+		if boolRes, ok := res.(bool); ok && boolRes {
 			return val, nil
 		}
 		return nil, nil

--- a/opFunction.go
+++ b/opFunction.go
@@ -251,6 +251,8 @@ func (x *opFunction) Do(currentData, originalData any) (dataToUse any, err error
 		switch resType := res.(type) {
 		case decimal.Decimal:
 			rtParams = append(rtParams, &FP_Number{resType})
+		case float64:
+			rtParams = append(rtParams, &FP_Number{decimal.NewFromFloat(resType)})
 		case string:
 			rtParams = append(rtParams, &FP_String{resType})
 		case bool:
@@ -338,7 +340,7 @@ func (x *opFunction) Parse(s *scanner, r rune) (nextR rune, err error) {
 			x.userString += string(r)
 			// This is the end of the function
 			return s.Scan(), nil
-		case '$', '@':
+		case '$', '@', '#':
 			// This is a path
 			if r, err = x.addOpToParamsAndParse(s, r); err != nil {
 				return r, err

--- a/opLogicalOperation.go
+++ b/opLogicalOperation.go
@@ -113,6 +113,7 @@ func (x *opLogicalOperation) Do(currentData, originalData any) (dataToUse any, e
 		if err != nil {
 			return nil, err
 		}
+
 		if b, ok := res.(bool); ok {
 			switch x.LogicalOperationType {
 			case LOT_And:

--- a/opPath.go
+++ b/opPath.go
@@ -315,10 +315,12 @@ func (x *opPath) Parse(s *scanner, r rune) (nextR rune, err error) {
 			return r, errors.Wrap(erInvalid(s, '@'), "cannot use '$' (root) inside filter")
 		}
 		x.StartAtRoot = true
+	case '#':
+		x.userString += string(r)
 	case '@':
 		// do nothing, this is the default
 	default:
-		return r, erInvalid(s, '$', '@')
+		return r, erInvalid(s, '$', '@', '#')
 	}
 	x.userString += string(r)
 

--- a/opPathIdent.go
+++ b/opPathIdent.go
@@ -152,10 +152,19 @@ var ErrKeyNotFound = fmt.Errorf("key not found")
 func (x *opPathIdent) Do(currentData, originalData any) (dataToUse any, err error) {
 	obj := currentData
 
-	if originalDataMap, ok := originalData.(map[string]any); ok {
-		if val, exists := originalDataMap["#"+x.IdentName]; exists {
-			return val, nil
+	originalDataVal := reflect.ValueOf(originalData)
+	switch originalDataVal.Kind() {
+	case reflect.Map:
+		for _, e := range originalDataVal.MapKeys() {
+			mks, ok := e.Interface().(string)
+			if ok {
+				if mks == "#"+x.IdentName {
+					return originalDataVal.MapIndex(e).Interface(), nil
+				}
+
+			}
 		}
+
 	}
 
 	// Ensure we are working with a map

--- a/opPathIdent.go
+++ b/opPathIdent.go
@@ -149,12 +149,17 @@ func (x *opPathIdent) Sprint(depth int) (out string) {
 
 var ErrKeyNotFound = fmt.Errorf("key not found")
 
-func (x *opPathIdent) Do(currentData, _ any) (dataToUse any, err error) {
-	// Ident paths require that the data is a struct or map[string]any
+func (x *opPathIdent) Do(currentData, originalData any) (dataToUse any, err error) {
+	obj := currentData
 
-	// Deal with maps
-	// if m, ok := currentData.(map[string]any); ok {
-	v := reflect.ValueOf(currentData)
+	if originalDataMap, ok := originalData.(map[string]any); ok {
+		if val, exists := originalDataMap["#"+x.IdentName]; exists {
+			return val, nil
+		}
+	}
+
+	// Ensure we are working with a map
+	v := reflect.ValueOf(obj)
 	switch v.Kind() {
 	case reflect.Pointer, reflect.Interface:
 		v = v.Elem()
@@ -189,9 +194,7 @@ func (x *opPathIdent) Do(currentData, _ any) (dataToUse any, err error) {
 		return nil, ErrKeyNotFound
 	}
 
-	// If we get here, the data must be a struct
-	// and we will look for the field by name
-	return getValuesByName(x.IdentName, currentData)
+	return getValuesByName(x.IdentName, obj)
 }
 
 func (x *opPathIdent) Parse(s *scanner, r rune) (nextR rune, err error) {


### PR DESCRIPTION
Provide the ability to define 'global variables' that can be set prior to the main operation, and then can be referred to by name. The plan here is to use the `#` character to define them, and to use them later. This will mean that variables can be used more efficiently. 